### PR TITLE
Updated to play core v1.6.3 to use installActivity.

### DIFF
--- a/app/src/main/java/com/google/android/samples/dynamicfeatures/BaseSplitActivity.kt
+++ b/app/src/main/java/com/google/android/samples/dynamicfeatures/BaseSplitActivity.kt
@@ -28,7 +28,7 @@ abstract class BaseSplitActivity : AppCompatActivity() {
 
     override fun attachBaseContext(newBase: Context?) {
         super.attachBaseContext(newBase)
-        SplitCompat.install(this)
+        SplitCompat.installActivity(this)
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
             'minSdk'            : 16,
             'targetSdk'         : 28,
             'kotlin'            : '1.3.41',
-            'playcore'          : '1.6.1'
+            'playcore'          : '1.6.3'
     ]
 
     ext.names = [

--- a/features/assets/src/main/AndroidManifest.xml
+++ b/features/assets/src/main/AndroidManifest.xml
@@ -20,9 +20,10 @@
     xmlns:dist="http://schemas.android.com/apk/distribution"
     package="com.google.android.samples.dynamicfeatures.ondemand.assets">
 
-    <dist:module
-        dist:onDemand="true"
-        dist:title="@string/module_assets">
+    <dist:module dist:title="@string/module_assets">
+        <dist:delivery>
+            <dist:on-demand/>
+        </dist:delivery>
         <dist:fusing dist:include="true" />
     </dist:module>
 

--- a/features/java/src/main/AndroidManifest.xml
+++ b/features/java/src/main/AndroidManifest.xml
@@ -19,9 +19,10 @@
     xmlns:dist="http://schemas.android.com/apk/distribution"
     package="com.google.android.samples.dynamicfeatures.ondemand.java">
 
-    <dist:module
-        dist:onDemand="true"
-        dist:title="@string/module_feature_java">
+    <dist:module dist:title="@string/module_feature_java">
+        <dist:delivery>
+            <dist:on-demand/>
+        </dist:delivery>
         <dist:fusing dist:include="true" />
     </dist:module>
 

--- a/features/kotlin/src/main/AndroidManifest.xml
+++ b/features/kotlin/src/main/AndroidManifest.xml
@@ -19,9 +19,10 @@
     xmlns:dist="http://schemas.android.com/apk/distribution"
     package="com.google.android.samples.dynamicfeatures.ondemand.kotlin">
 
-    <dist:module
-        dist:onDemand="true"
-        dist:title="@string/module_feature_kotlin">
+    <dist:module dist:title="@string/module_feature_kotlin">
+        <dist:delivery>
+            <dist:on-demand/>
+        </dist:delivery>
         <dist:fusing dist:include="true" />
     </dist:module>
 

--- a/features/native/src/main/AndroidManifest.xml
+++ b/features/native/src/main/AndroidManifest.xml
@@ -19,9 +19,10 @@
     xmlns:dist="http://schemas.android.com/apk/distribution"
     package="com.google.android.samples.dynamicfeatures.ondemand.ccode">
 
-    <dist:module
-        dist:onDemand="true"
-        dist:title="@string/module_native">
+    <dist:module dist:title="@string/module_native">
+        <dist:delivery>
+            <dist:on-demand/>
+        </dist:delivery>
         <dist:fusing dist:include="true" />
     </dist:module>
 


### PR DESCRIPTION
- BaseSplitActivity now uses SplitCompat.installActivity.
- Updated delivery syntax to the new one (`<dist:delivery>`).