### PR TITLE
Bumps versions for AFox

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name="android.intent.action.VIEW" />

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,11 @@
 buildscript {
 
     ext.versions = [
-            'compileSdk'        : 28,
+            'compileSdk'        : 31,
             'minSdk'            : 16,
-            'targetSdk'         : 28,
-            'kotlin'            : '1.3.41',
-            'playcore'          : '1.6.3'
+            'targetSdk'         : 31,
+            'kotlin'            : '1.6.10',
+            'playcore'          : '1.10.3'
     ]
 
     ext.names = [
@@ -32,10 +32,10 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -46,6 +46,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/features/java/src/main/AndroidManifest.xml
+++ b/features/java/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
     package="com.google.android.samples.dynamicfeatures.ondemand.java">
 
     <application>
-        <activity android:name="com.google.android.samples.dynamicfeatures.ondemand.JavaSampleActivity">
+        <activity android:name="com.google.android.samples.dynamicfeatures.ondemand.JavaSampleActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>

--- a/features/kotlin/src/main/AndroidManifest.xml
+++ b/features/kotlin/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
     package="com.google.android.samples.dynamicfeatures.ondemand.kotlin">
 
     <application>
-        <activity android:name="com.google.android.samples.dynamicfeatures.ondemand.KotlinSampleActivity">
+        <activity android:name="com.google.android.samples.dynamicfeatures.ondemand.KotlinSampleActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>

--- a/features/native/src/main/AndroidManifest.xml
+++ b/features/native/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
     package="com.google.android.samples.dynamicfeatures.ondemand.ccode">
 
     <application>
-        <activity android:name="com.google.android.samples.dynamicfeatures.ondemand.NativeSampleActivity">
+        <activity android:name="com.google.android.samples.dynamicfeatures.ondemand.NativeSampleActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
Kotlin and Gradle Plugin versions updated
...kotlin-stdlib-jdk7.. line removed
android:exported="true" in Manifests set
libraries versions updated
jcenter() replaced with mavenCentral()
android.useAndroidX=true added otherwise build failed